### PR TITLE
Fix Basic Interpolation example

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ i18next.t('unspecifiedKey'); // 'unspecifiedKey'
 
 ```json
 {
-  "myKey": "Hello {{name}}!"
+  "key": "Hello {{name}}!"
 }
 ```
 


### PR DESCRIPTION
The example given on the `Basic Interpolation` section has a different key from its usage in line 97.