### PR TITLE
[Feature] Adds fallback namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## [0.0.1+8]
 
 * Bumps analysis options #9
+* Adds fallback namespace #10
+* Refactors Translator to a callable class #10
+* Refactors interpolator class to global pure functions #10
 
 ## [0.0.1+7]
 

--- a/lib/src/i18next.dart
+++ b/lib/src/i18next.dart
@@ -2,7 +2,6 @@ import 'dart:ui';
 
 import 'package:flutter/widgets.dart';
 
-import 'interpolator.dart';
 import 'options.dart';
 import 'plural_resolver.dart';
 import 'resource_store.dart';
@@ -36,7 +35,6 @@ import 'translator.dart';
 class I18Next {
   I18Next(this.locale, this.resourceStore, {I18NextOptions options})
       : assert(resourceStore != null),
-        interpolator = Interpolator(),
         pluralResolver = PluralResolver(),
         options = I18NextOptions.base.apply(options);
 
@@ -48,7 +46,6 @@ class I18Next {
   ///
   /// Cannot be null.
   final ResourceStore resourceStore;
-  final Interpolator interpolator;
   final PluralResolver pluralResolver;
 
   /// The options used to find and format matching interpolations.
@@ -93,11 +90,8 @@ class I18Next {
     locale ??= this.locale;
     final newOptions = this.options.apply(options);
 
-    return Translator(
-          interpolator,
-          pluralResolver,
-          resourceStore,
-        ).translate(key, locale, variables, newOptions) ??
+    return Translator(pluralResolver, resourceStore)
+            .translate(key, locale, variables, newOptions) ??
         key;
   }
 

--- a/lib/src/i18next.dart
+++ b/lib/src/i18next.dart
@@ -91,7 +91,7 @@ class I18Next {
     final newOptions = this.options.apply(options);
 
     return Translator(pluralResolver, resourceStore)
-            .translate(key, locale, variables, newOptions) ??
+            .call(key, locale, variables, newOptions) ??
         key;
   }
 

--- a/lib/src/interpolator.dart
+++ b/lib/src/interpolator.dart
@@ -6,101 +6,97 @@ import 'options.dart';
 typedef Translate = String Function(
     String, Locale, Map<String, Object>, I18NextOptions);
 
-class Interpolator {
-  Interpolator();
+/// Replaces occurrences of matches in [string] for the named values
+/// in [options] (if they exist), by first passing through the
+/// [I18NextOptions.formatter] before joining the resulting string.
+///
+/// - 'Hello {{name}}' + {name: 'World'} -> 'Hello World'.
+///   This example illustrates a simple interpolation.
+/// - 'Now is {{date, dd/MM}}' + {date: DateTime.now()} -> 'Now is 23/09'.
+///   In this example, [I18NextOptions.formatter] must be able to
+///   properly format the date.
+String interpolate(
+  Locale locale,
+  String string,
+  Map<String, Object> variables,
+  I18NextOptions options,
+) {
+  assert(string != null);
+  assert(options != null);
+  variables ??= {};
 
-  /// Replaces occurrences of matches in [string] for the named values
-  /// in [options] (if they exist), by first passing through the
-  /// [I18NextOptions.formatter] before joining the resulting string.
-  ///
-  /// - 'Hello {{name}}' + {name: 'World'} -> 'Hello World'.
-  ///   This example illustrates a simple interpolation.
-  /// - 'Now is {{date, dd/MM}}' + {date: DateTime.now()} -> 'Now is 23/09'.
-  ///   In this example, [I18NextOptions.formatter] must be able to
-  ///   properly format the date.
-  String interpolate(
-    Locale locale,
-    String string,
-    Map<String, Object> variables,
-    I18NextOptions options,
-  ) {
-    assert(string != null);
-    assert(options != null);
-    variables ??= {};
-
-    return string.splitMapJoin(
-      interpolationPattern(options),
-      onMatch: (match) {
-        final RegExpMatch regExpMatch = match;
-        final variable = regExpMatch.namedGroup('variable');
-
-        String result;
-        final value = variables[variable];
-        if (value != null) {
-          final format = regExpMatch.namedGroup('format');
-          result = options.formatter(value, format, locale);
-        }
-        return result ?? regExpMatch.group(0);
-      },
-    );
-  }
-
-  /// Replaces occurrences of nested key-values in [string] for other
-  /// key-values. Essentially calls [I18Next.translate] with the nested value.
-  ///
-  /// E.g.:
-  /// ```json
-  /// {
-  ///   key1: "Hello $t(key2)!"
-  ///   key2: "World"
-  /// }
-  /// i18Next.t('key1') // "Hello World!"
-  /// ```
-  String nest(
-    Locale locale,
-    String string,
-    Translate translate,
-    Map<String, Object> variables,
-    I18NextOptions options,
-  ) {
-    assert(string != null);
-    assert(translate != null);
-    assert(options != null);
-    variables ??= {};
-
-    return string.splitMapJoin(nestingPattern(options), onMatch: (match) {
+  return string.splitMapJoin(
+    interpolationPattern(options),
+    onMatch: (match) {
       final RegExpMatch regExpMatch = match;
-      final key = regExpMatch.namedGroup('key');
+      final variable = regExpMatch.namedGroup('variable');
 
       String result;
-      if (key != null && key.isNotEmpty) {
-        final newVariables = Map<String, Object>.of(variables);
-        final varsString = regExpMatch.namedGroup('variables');
-        if (varsString != null && varsString.isNotEmpty) {
-          try {
-            newVariables.addAll(jsonDecode(varsString));
-          } catch (error) {
-            assert(true, error);
-          }
-        }
-
-        result = translate(key, locale, newVariables, options);
+      final value = variables[variable];
+      if (value != null) {
+        final format = regExpMatch.namedGroup('format');
+        result = options.formatter(value, format, locale);
       }
       return result ?? regExpMatch.group(0);
-    });
-  }
-
-  static RegExp interpolationPattern(I18NextOptions options) => RegExp(
-        '${options.interpolationPrefix}'
-        '(?<variable>.*?)'
-        '(${options.interpolationSeparator}\\s*(?<format>.*?)\\s*)?'
-        '${options.interpolationSuffix}',
-      );
-
-  static RegExp nestingPattern(I18NextOptions options) => RegExp(
-        '${options.nestingPrefix}'
-        '(?<key>.*?)'
-        '(${options.nestingSeparator}\\s*(?<variables>.*?)\\s*)?'
-        '${options.nestingSuffix}',
-      );
+    },
+  );
 }
+
+/// Replaces occurrences of nested key-values in [string] for other
+/// key-values. Essentially calls [I18Next.translate] with the nested value.
+///
+/// E.g.:
+/// ```json
+/// {
+///   key1: "Hello $t(key2)!"
+///   key2: "World"
+/// }
+/// i18Next.t('key1') // "Hello World!"
+/// ```
+String nest(
+  Locale locale,
+  String string,
+  Translate translate,
+  Map<String, Object> variables,
+  I18NextOptions options,
+) {
+  assert(string != null);
+  assert(translate != null);
+  assert(options != null);
+  variables ??= {};
+
+  return string.splitMapJoin(nestingPattern(options), onMatch: (match) {
+    final RegExpMatch regExpMatch = match;
+    final key = regExpMatch.namedGroup('key');
+
+    String result;
+    if (key != null && key.isNotEmpty) {
+      final newVariables = Map<String, Object>.of(variables);
+      final varsString = regExpMatch.namedGroup('variables');
+      if (varsString != null && varsString.isNotEmpty) {
+        try {
+          newVariables.addAll(jsonDecode(varsString));
+        } catch (error) {
+          assert(true, error);
+        }
+      }
+
+      result = translate(key, locale, newVariables, options);
+    }
+    return result ?? regExpMatch.group(0);
+  });
+}
+
+RegExp interpolationPattern(I18NextOptions options) => RegExp(
+      '${options.interpolationPrefix}'
+      '(?<variable>.*?)'
+      '(${options.interpolationSeparator}\\s*(?<format>.*?)\\s*)?'
+      '${options.interpolationSuffix}',
+    );
+
+RegExp nestingPattern(I18NextOptions options) => RegExp(
+      '${options.nestingPrefix}'
+      '(?<key>.*?)'
+      '(${options.nestingSeparator}\\s*(?<variables>.*?)\\s*)?'
+      '${options.nestingSuffix}',
+    );

--- a/lib/src/options.dart
+++ b/lib/src/options.dart
@@ -7,6 +7,7 @@ import 'utils.dart';
 /// Contains all options for [I18Next] to work properly.
 class I18NextOptions extends Diagnosticable {
   I18NextOptions({
+    this.fallbackNamespace,
     this.namespaceSeparator,
     this.contextSeparator,
     this.pluralSeparator,
@@ -23,6 +24,7 @@ class I18NextOptions extends Diagnosticable {
 
   /// Creates the base options
   static final I18NextOptions base = I18NextOptions(
+    fallbackNamespace: null,
     namespaceSeparator: ':',
     contextSeparator: '_',
     pluralSeparator: '_',
@@ -36,6 +38,12 @@ class I18NextOptions extends Diagnosticable {
     pluralSuffix: 'plural',
     formatter: defaultFormatter,
   );
+
+  /// The namespace used to fallback when no key matches were found on the
+  /// current namespace.
+  ///
+  /// Defaults to null.
+  final String fallbackNamespace;
 
   /// The separator used when splitting the key.
   ///
@@ -119,6 +127,7 @@ class I18NextOptions extends Diagnosticable {
   I18NextOptions apply(I18NextOptions other) {
     if (other == null) return this;
     return I18NextOptions(
+      fallbackNamespace: other.fallbackNamespace ?? fallbackNamespace,
       namespaceSeparator: other.namespaceSeparator ?? namespaceSeparator,
       contextSeparator: other.contextSeparator ?? contextSeparator,
       pluralSeparator: other.pluralSeparator ?? pluralSeparator,

--- a/lib/src/translator.dart
+++ b/lib/src/translator.dart
@@ -1,20 +1,17 @@
 import 'dart:ui';
 
-import 'interpolator.dart';
+import 'interpolator.dart' as interpolator;
 import 'options.dart';
 import 'plural_resolver.dart';
 import 'resource_store.dart';
 
 class Translator {
   Translator(
-    this.interpolator,
     this.pluralResolver,
     this.resourceStore,
-  )   : assert(interpolator != null),
-        assert(pluralResolver != null),
+  )   : assert(pluralResolver != null),
         assert(resourceStore != null);
 
-  final Interpolator interpolator;
   final PluralResolver pluralResolver;
   final ResourceStore resourceStore;
 

--- a/lib/src/translator.dart
+++ b/lib/src/translator.dart
@@ -15,7 +15,7 @@ class Translator {
   final PluralResolver pluralResolver;
   final ResourceStore resourceStore;
 
-  String translate(
+  String call(
     String key,
     Locale locale,
     Map<String, Object> variables,
@@ -104,7 +104,7 @@ class Translator {
     String result;
     if (value != null) {
       result = interpolator.interpolate(locale, value, variables, options);
-      result = interpolator.nest(locale, result, translate, variables, options);
+      result = interpolator.nest(locale, result, call, variables, options);
     }
     return result;
   }

--- a/test/i18next_test.dart
+++ b/test/i18next_test.dart
@@ -9,6 +9,7 @@ class MockLocalizationsDataSource extends Mock
     implements LocalizationDataSource {}
 
 void main() {
+  const namespace = 'local_namespace';
   const locale = Locale('en');
   I18Next i18next;
   MockResourceStore resourceStore;
@@ -18,7 +19,7 @@ void main() {
     i18next = I18Next(locale, resourceStore);
   });
 
-  void mockKey(String key, String answer, {String ns = ''}) {
+  void mockKey(String key, String answer, {String ns = namespace}) {
     when(resourceStore.retrieve(any, ns, key, any)).thenReturn(answer);
   }
 
@@ -71,7 +72,7 @@ void main() {
 
   test('given an existing string key', () {
     mockKey('myKey', 'This is my key');
-    expect(i18next.t('myKey'), 'This is my key');
+    expect(i18next.t('$namespace:myKey'), 'This is my key');
   });
 
   test('given a non-existing or non matching key', () {
@@ -83,10 +84,10 @@ void main() {
     const anotherLocale = Locale('another');
     mockKey('key', 'my value');
 
-    expect(i18next.t('key', locale: anotherLocale), 'my value');
+    expect(i18next.t('$namespace:key', locale: anotherLocale), 'my value');
     verify(resourceStore.retrieve(
       anotherLocale,
-      '',
+      namespace,
       'key',
       any,
     )).called(1);
@@ -103,7 +104,7 @@ void main() {
       );
       mockKey('key', 'no interpolations here');
 
-      expect(i18next.t('key'), 'no interpolations here');
+      expect(i18next.t('$namespace:key'), 'no interpolations here');
     });
 
     test('with no matching variables', () {
@@ -120,7 +121,7 @@ void main() {
       mockKey('key', 'leading {{value, format}} trailing');
 
       expect(
-        i18next.t('key', variables: {'name': 'World'}),
+        i18next.t('$namespace:key', variables: {'name': 'World'}),
         'leading {{value, format}} trailing',
       );
     });
@@ -136,7 +137,7 @@ void main() {
       mockKey('key', 'leading {{value, format}} trailing');
 
       expect(
-        i18next.t('key', variables: {'value': 'eulav'}),
+        i18next.t('$namespace:key', variables: {'value': 'eulav'}),
         'leading eulav trailing',
       );
     });
@@ -159,7 +160,7 @@ void main() {
       mockKey('key', 'leading {{value, format}} trailing');
 
       expect(
-        i18next.t('key', variables: {'value': 'eulav'}),
+        i18next.t('$namespace:key', variables: {'value': 'eulav'}),
         'leading eulav trailing',
       );
     });
@@ -187,7 +188,7 @@ void main() {
               '{{value2, format2}} trailing');
 
       expect(
-        i18next.t('key', variables: {
+        i18next.t('$namespace:key', variables: {
           'value1': '1eulav',
           'value2': '2eulav',
         }),
@@ -205,41 +206,53 @@ void main() {
     });
 
     test('given key without count', () {
-      expect(i18next.t('friend'), 'A friend');
+      expect(i18next.t('$namespace:friend'), 'A friend');
     });
 
     test('given key with count', () {
-      expect(i18next.t('friend', count: 0), '0 friends');
-      expect(i18next.t('friend', count: 1), 'A friend');
-      expect(i18next.t('friend', count: -1), '-1 friends');
-      expect(i18next.t('friend', count: 99), '99 friends');
+      expect(i18next.t('$namespace:friend', count: 0), '0 friends');
+      expect(i18next.t('$namespace:friend', count: 1), 'A friend');
+      expect(i18next.t('$namespace:friend', count: -1), '-1 friends');
+      expect(i18next.t('$namespace:friend', count: 99), '99 friends');
     });
 
     test('given key with count in variables', () {
-      expect(i18next.t('friend', variables: {'count': 0}), '0 friends');
-      expect(i18next.t('friend', variables: {'count': 1}), 'A friend');
-      expect(i18next.t('friend', variables: {'count': -1}), '-1 friends');
-      expect(i18next.t('friend', variables: {'count': 99}), '99 friends');
+      expect(
+        i18next.t('$namespace:friend', variables: {'count': 0}),
+        '0 friends',
+      );
+      expect(
+        i18next.t('$namespace:friend', variables: {'count': 1}),
+        'A friend',
+      );
+      expect(
+        i18next.t('$namespace:friend', variables: {'count': -1}),
+        '-1 friends',
+      );
+      expect(
+        i18next.t('$namespace:friend', variables: {'count': 99}),
+        '99 friends',
+      );
     });
 
     test('given key with both count property and in variables', () {
       expect(
-        i18next.t('friend', count: 0, variables: {'count': 1}),
+        i18next.t('$namespace:friend', count: 0, variables: {'count': 1}),
         '0 friends',
       );
       expect(
-        i18next.t('friend', count: 1, variables: {'count': 0}),
+        i18next.t('$namespace:friend', count: 1, variables: {'count': 0}),
         'A friend',
       );
     });
 
     test('given key with count and unmmaped context', () {
       expect(
-        i18next.t('friend', count: 1, context: 'something'),
+        i18next.t('$namespace:friend', count: 1, context: 'something'),
         'A friend',
       );
       expect(
-        i18next.t('friend', count: 99, context: 'something'),
+        i18next.t('$namespace:friend', count: 99, context: 'something'),
         '99 friends',
       );
     });
@@ -255,58 +268,66 @@ void main() {
     });
 
     test('given key without context', () {
-      expect(i18next.t('friend'), 'A friend');
+      expect(i18next.t('$namespace:friend'), 'A friend');
     });
 
     test('given key with mapped context', () {
-      expect(i18next.t('friend', context: 'male'), 'A boyfriend');
-      expect(i18next.t('friend', context: 'female'), 'A girlfriend');
+      expect(i18next.t('$namespace:friend', context: 'male'), 'A boyfriend');
+      expect(i18next.t('$namespace:friend', context: 'female'), 'A girlfriend');
     });
 
     test('given key with mapped context in variables', () {
       expect(
-        i18next.t('friend', variables: {'context': 'male'}),
+        i18next.t('$namespace:friend', variables: {'context': 'male'}),
         'A boyfriend',
       );
       expect(
-        i18next.t('friend', variables: {'context': 'female'}),
+        i18next.t('$namespace:friend', variables: {'context': 'female'}),
         'A girlfriend',
       );
     });
 
     test('given key with both mapped context property and in variables', () {
       expect(
-        i18next.t('friend', context: 'female', variables: {'context': 'male'}),
+        i18next.t(
+          '$namespace:friend',
+          context: 'female',
+          variables: {'context': 'male'},
+        ),
         'A girlfriend',
       );
       expect(
-        i18next.t('friend', context: 'male', variables: {'context': 'female'}),
+        i18next.t(
+          '$namespace:friend',
+          context: 'male',
+          variables: {'context': 'female'},
+        ),
         'A boyfriend',
       );
     });
 
     test('given key with unmaped context', () {
-      expect(i18next.t('friend', context: 'other'), 'A friend');
+      expect(i18next.t('$namespace:friend', context: 'other'), 'A friend');
     });
 
     test('given key with mapped context and count', () {
       expect(
-        i18next.t('friend', context: 'male', count: 0),
+        i18next.t('$namespace:friend', context: 'male', count: 0),
         'A boyfriend',
       );
       expect(
-        i18next.t('friend', context: 'male', count: 1),
+        i18next.t('$namespace:friend', context: 'male', count: 1),
         'A boyfriend',
       );
     });
 
     test('given key with unmapped context and count', () {
       expect(
-        i18next.t('friend', context: 'other', count: 1),
+        i18next.t('$namespace:friend', context: 'other', count: 1),
         'A friend',
       );
       expect(
-        i18next.t('friend', context: 'other', count: 99),
+        i18next.t('$namespace:friend', context: 'other', count: 99),
         'A friend',
       );
     });
@@ -324,30 +345,30 @@ void main() {
 
     test('given key with mapped context and count', () {
       expect(
-        i18next.t('friend', context: 'male', count: 0),
+        i18next.t('$namespace:friend', context: 'male', count: 0),
         '0 boyfriends',
       );
       expect(
-        i18next.t('friend', context: 'male', count: 1),
+        i18next.t('$namespace:friend', context: 'male', count: 1),
         'A boyfriend',
       );
       expect(
-        i18next.t('friend', context: 'female', count: 0),
+        i18next.t('$namespace:friend', context: 'female', count: 0),
         '0 girlfriends',
       );
       expect(
-        i18next.t('friend', context: 'female', count: 1),
+        i18next.t('$namespace:friend', context: 'female', count: 1),
         'A girlfriend',
       );
     });
 
     test('given key with unmmaped context and count', () {
       expect(
-        i18next.t('friend', context: 'other', count: 0),
+        i18next.t('$namespace:friend', context: 'other', count: 0),
         '0 friends',
       );
       expect(
-        i18next.t('friend', context: 'other', count: 1),
+        i18next.t('$namespace:friend', context: 'other', count: 1),
         'A friend',
       );
     });
@@ -360,30 +381,33 @@ void main() {
 
     test('given empty interpolation', () {
       mockKey('key', 'This is some {{}}');
-      expect(i18next.t('key'), 'This is some {{}}');
+      expect(i18next.t('$namespace:key'), 'This is some {{}}');
     });
 
     test('given non matching arguments', () {
       expect(
-        i18next.t('key', variables: {'none': 'none'}),
+        i18next.t('$namespace:key', variables: {'none': 'none'}),
         '{{first}}, {{second}}, and then {{third}}!',
       );
     });
 
     test('given partially matching arguments', () {
       expect(
-        i18next.t('key', variables: {'first': 'fst'}),
+        i18next.t('$namespace:key', variables: {'first': 'fst'}),
         'fst, {{second}}, and then {{third}}!',
       );
       expect(
-        i18next.t('key', variables: {'first': 'fst', 'third': 'trd'}),
+        i18next.t(
+          '$namespace:key',
+          variables: {'first': 'fst', 'third': 'trd'},
+        ),
         'fst, {{second}}, and then trd!',
       );
     });
 
     test('given all matching arguments', () {
       expect(
-        i18next.t('key', variables: {
+        i18next.t('$namespace:key', variables: {
           'first': 'fst',
           'second': 'snd',
           'third': 'trd',
@@ -394,7 +418,7 @@ void main() {
 
     test('given extra matching arguments', () {
       expect(
-        i18next.t('key', variables: {
+        i18next.t('$namespace:key', variables: {
           'first': 'fst',
           'second': 'snd',
           'third': 'trd',
@@ -409,7 +433,7 @@ void main() {
     test('when nested key is not found', () {
       mockKey('key', r'This is my $t(anotherKey)');
 
-      expect(i18next.t('key'), r'This is my $t(anotherKey)');
+      expect(i18next.t('$namespace:key'), r'This is my $t(anotherKey)');
     });
 
     test('given multiple simple key substitutions', () {
@@ -417,7 +441,51 @@ void main() {
       mockKey('nesting2', r'2 $t(nesting3)');
       mockKey('nesting3', '3');
 
-      expect(i18next.t('nesting1'), '1 2 3');
+      expect(i18next.t('$namespace:nesting1'), '1 2 3');
+    });
+
+    test('given a grouped key substitution', () {
+      mockKey('keyA', 'A');
+      mockKey('group.keyB', 'B');
+      mockKey('local', r'$t(keyA), and $t(group.keyB)!');
+
+      expect(i18next.t('$namespace:local'), 'A, and B!');
+    });
+
+    test('given a global fallback key substitution', () {
+      const fallbackNamespace = 'fallback_namespace';
+      i18next = I18Next(
+        locale,
+        resourceStore,
+        options: I18NextOptions(fallbackNamespace: fallbackNamespace),
+      );
+
+      mockKey('keyZ', 'Z', ns: fallbackNamespace);
+      mockKey('keyA', 'A', ns: namespace);
+
+      mockKey('example', r'$t(keyA), and $t(keyZ)!', ns: namespace);
+
+      expect(i18next.t('$namespace:example'), 'A, and Z!');
+    });
+
+    test('when nested local and fallback namespaces have same key', () {
+      const fallbackNamespace = 'fallback_namespace';
+      i18next = I18Next(
+        locale,
+        resourceStore,
+        options: I18NextOptions(fallbackNamespace: fallbackNamespace),
+      );
+
+      mockKey('keyX', 'Global X', ns: fallbackNamespace);
+      mockKey('keyX', 'Local X', ns: namespace);
+      mockKey(
+        'example',
+        // explicit namespace key nesting
+        '\$t(keyX), and \$t($fallbackNamespace:keyX)!',
+        ns: namespace,
+      );
+
+      expect(i18next.t('$namespace:example'), 'Local X, and Global X!');
     });
 
     test('interpolation from immediate variables', () {
@@ -425,7 +493,7 @@ void main() {
       mockKey('key2', 'say: {{val}}');
 
       expect(
-        i18next.t('key2', variables: {'val': r'$t(key1)'}),
+        i18next.t('$namespace:key2', variables: {'val': r'$t(key1)'}),
         'say: hello world',
       );
     });
@@ -435,7 +503,7 @@ void main() {
       mockKey('key2', r'say: $t(key1)');
 
       expect(
-        i18next.t('key2', variables: {'name': 'world'}),
+        i18next.t('$namespace:key2', variables: {'name': 'world'}),
         'say: hello world',
       );
     });
@@ -449,7 +517,7 @@ void main() {
       mockKey('girls_plural', '{{count}} girls');
 
       expect(
-        i18next.t('girlsAndBoys', count: 2, variables: {'girls': 3}),
+        i18next.t('$namespace:girlsAndBoys', count: 2, variables: {'girls': 3}),
         '3 girls and 2 boys',
       );
     });

--- a/test/interpolator_test.dart
+++ b/test/interpolator_test.dart
@@ -6,40 +6,35 @@ import 'package:i18next/src/interpolator.dart';
 
 void main() {
   final baseOptions = I18NextOptions.base;
-  Interpolator interpolator;
 
-  setUp(() {
-    interpolator = Interpolator();
-  });
-
-  group('#interpolate', () {
-    String interpolate(
+  group('interpolate', () {
+    String interpol(
       String string, {
       Map<String, Object> variables,
       Locale locale,
       ArgumentFormatter formatter,
     }) {
       final options = baseOptions.apply(I18NextOptions(formatter: formatter));
-      return interpolator.interpolate(locale, string, variables, options);
+      return interpolate(locale, string, variables, options);
     }
 
     test('given string null', () {
       expect(
-        () => interpolator.interpolate(null, null, null, baseOptions),
+        () => interpolate(null, null, null, baseOptions),
         throwsAssertionError,
       );
     });
 
     test('given options null', () {
       expect(
-        () => interpolator.interpolate(null, '', null, null),
+        () => interpolate(null, '', null, null),
         throwsAssertionError,
       );
     });
 
     test('given a non matching string', () {
       expect(
-        interpolate(
+        interpol(
           'This is a normal string',
           formatter: expectAsync3(null, count: 0),
         ),
@@ -50,7 +45,7 @@ void main() {
     group('given a matching string', () {
       test('without variable or format', () {
         expect(
-          interpolate(
+          interpol(
             'This is a {{}} string',
             formatter: expectAsync3(null, count: 0),
           ),
@@ -61,7 +56,7 @@ void main() {
       group('with variable only', () {
         test('without variables', () {
           expect(
-            interpolate(
+            interpol(
               'This is a {{variable}} string',
               formatter: expectAsync3(null, count: 0),
             ),
@@ -71,7 +66,7 @@ void main() {
 
         test('with replaceable variables', () {
           expect(
-            interpolate(
+            interpol(
               'This is a {{variable}} string',
               variables: {'variable': 'my variable'},
               formatter: expectAsync3((variable, format, locale) {
@@ -87,7 +82,7 @@ void main() {
 
         test('without replaceable variables', () {
           expect(
-            interpolate(
+            interpol(
               'This is a {{variable}} string',
               variables: {'another': 'value'},
               formatter: expectAsync3(null, count: 0),
@@ -99,7 +94,7 @@ void main() {
 
       test('with format only', () {
         expect(
-          interpolate(
+          interpol(
             'This is a {{, some format}} string',
             formatter: expectAsync3(null, count: 0),
           ),
@@ -109,7 +104,7 @@ void main() {
 
       test('with variable and format and replaceable variables', () {
         expect(
-          interpolate(
+          interpol(
             'This is a {{variable, format}} string',
             variables: {'variable': 'my variable'},
             formatter: expectAsync3((variable, format, locale) {
@@ -126,7 +121,7 @@ void main() {
       test('given locale', () {
         const locale = Locale('any');
         expect(
-          interpolate(
+          interpol(
             'This is a {{variable}} string',
             locale: locale,
             variables: {'variable': 'my variable'},
@@ -143,8 +138,8 @@ void main() {
     });
   });
 
-  group('#nest', () {
-    String nest(
+  group('nest', () {
+    String nst(
       String string, {
       Locale locale,
       Map<String, Object> variables,
@@ -152,13 +147,12 @@ void main() {
       I18NextOptions options,
     }) {
       translate ??= (a, b, c, d) => a;
-      return interpolator.nest(
-          locale, string, translate, variables, options ?? baseOptions);
+      return nest(locale, string, translate, variables, options ?? baseOptions);
     }
 
     test('given string null', () {
       expect(
-        () => interpolator.nest(
+        () => nest(
           null,
           null,
           expectAsync4(null, count: 0),
@@ -171,14 +165,14 @@ void main() {
 
     test('given translate null', () {
       expect(
-        () => interpolator.nest(null, '', null, null, baseOptions),
+        () => nest(null, '', null, null, baseOptions),
         throwsAssertionError,
       );
     });
 
     test('given options null', () {
       expect(
-        () => interpolator.nest(
+        () => nest(
           null,
           '',
           expectAsync4(null, count: 0),
@@ -191,7 +185,7 @@ void main() {
 
     test('given a non matching string', () {
       expect(
-        nest(
+        nst(
           'This is my unmatching string',
           translate: expectAsync4(null, count: 0),
         ),
@@ -202,7 +196,7 @@ void main() {
     group('given a nesting string', () {
       test('without key or variables', () {
         expect(
-          nest(
+          nst(
             r'This is my $t() string',
             translate: expectAsync4(null, count: 0),
           ),
@@ -212,7 +206,7 @@ void main() {
 
       test('with key only', () {
         expect(
-          nest(
+          nst(
             r'This is my $t(key) string',
             translate: expectAsync4((key, b, c, d) {
               expect(key, 'key');
@@ -225,7 +219,7 @@ void main() {
 
       test('with variables only', () {
         expect(
-          nest(
+          nst(
             r'This is my $t(, {"x": "y"}) string',
             translate: expectAsync4(null, count: 0),
           ),
@@ -239,7 +233,7 @@ void main() {
 
           test('the deserialized variables are passed', () {
             expect(
-              nest(
+              nst(
                 r'This is my $t(key, {"x":"y"}) string',
                 translate: expectAsync4((key, b, variables, d) {
                   expect(key, 'key');
@@ -253,7 +247,7 @@ void main() {
 
           test('the new variables are merged with the previous variables', () {
             expect(
-              nest(
+              nst(
                 string,
                 variables: const {'x': 'x', 'y': 'y', 'z': 'z'},
                 translate: expectAsync4((key, b, variables, d) {
@@ -273,7 +267,7 @@ void main() {
 
         test('when variables are a malformed json', () {
           expect(
-            nest(
+            nst(
               r'This is my $t(key, "x") string',
               translate: expectAsync4((key, b, variables, d) {
                 expect(key, 'key');
@@ -288,7 +282,7 @@ void main() {
 
       test('with multiple split points', () {
         expect(
-          nest(
+          nst(
             r'This is my $t(key, {"a":"a"}, {"b":"b"}) string',
             translate: expectAsync4((key, b, variables, d) {
               expect(key, 'key');
@@ -304,7 +298,7 @@ void main() {
         const locale = Locale('any');
 
         expect(
-          nest(
+          nst(
             r'This is my $t(key) string',
             locale: locale,
             options: baseOptions,
@@ -320,8 +314,8 @@ void main() {
     });
   });
 
-  group('.interpolationPattern', () {
-    final pattern = Interpolator.interpolationPattern(baseOptions);
+  group('interpolationPattern', () {
+    final pattern = interpolationPattern(baseOptions);
 
     Iterable<List<String>> allMatches(String text) =>
         pattern.allMatches(text).map((match) => [
@@ -400,8 +394,8 @@ void main() {
     });
   });
 
-  group('.nestingPattern', () {
-    final pattern = Interpolator.nestingPattern(baseOptions);
+  group('nestingPattern', () {
+    final pattern = nestingPattern(baseOptions);
 
     Iterable<List<String>> allMatches(String text) =>
         pattern.allMatches(text).map((match) => [


### PR DESCRIPTION
- A fallback namespace can be passed on `I18NextOptions`
When a key for a local/current namespace can't be resolved, it attempts the same key on the fallback.
The matching order always tries the graceful key fallbacks (context and pluralization) before moving to the next namespace.
- Refactors the Interpolator class to pure functions instead
- Refactor Translator to be a callable class (this eases instance-level contexts like current namespace)
- Fixes #8 