### PR TITLE
Enables support for multiple plural forms

### DIFF
--- a/example/localizations/en-US/counter.json
+++ b/example/localizations/en-US/counter.json
@@ -2,7 +2,7 @@
   "clickMe": "Click me",
   "clicked": "You clicked {{count}} time!",
   "clicked_plural": "You clicked {{count}} times!",
-  "clicked_plural_0": "No clicks",
-  "clicked_plural_2": "Double tap",
+  "clicked_0": "No clicks",
+  "clicked_2": "Double click",
   "resetCounter": "Reset Counter"
 }

--- a/example/localizations/en-US/counter.json
+++ b/example/localizations/en-US/counter.json
@@ -2,5 +2,7 @@
   "clickMe": "Click me",
   "clicked": "You clicked {{count}} time!",
   "clicked_plural": "You clicked {{count}} times!",
+  "clicked_plural_0": "No clicks",
+  "clicked_plural_2": "Double tap",
   "resetCounter": "Reset Counter"
 }

--- a/lib/src/plural_resolver.dart
+++ b/lib/src/plural_resolver.dart
@@ -4,7 +4,7 @@ import 'options.dart';
 
 /// A callback function to determine if exists
 /// the key for an specifc plural modifier
-typedef CheckerKeyFunction = bool Function(
+typedef KeyExists = bool Function(
   String pluralModifier,
 );
 
@@ -15,24 +15,24 @@ class PluralResolver {
   String pluralize(
     int count,
     I18NextOptions options,
-    CheckerKeyFunction find,
+    KeyExists validateKey,
   ) {
     final shouldLookForPluralKeys = count != 1;
     const resultForNonRequiredPlural = '';
 
-    return !shouldLookForPluralKeys
-        ? resultForNonRequiredPlural
-        : _pluralKey(count, options, find);
+    return shouldLookForPluralKeys
+        ? _pluralKey(count, options, validateKey)
+        : resultForNonRequiredPlural;
   }
 
   String _pluralKey(
     int count,
     I18NextOptions options,
-    CheckerKeyFunction find,
+    KeyExists validateKey,
   ) {
     final baseKey = '${options.pluralSeparator}${options.pluralSuffix}';
-    final specicPluralKey = '$baseKey${options.pluralSeparator}$count';
-    final existSpecicPlural = find(specicPluralKey);
+    final specicPluralKey = '${options.pluralSeparator}$count';
+    final existSpecicPlural = validateKey(specicPluralKey);
 
     return existSpecicPlural ? specicPluralKey : baseKey;
   }

--- a/lib/src/plural_resolver.dart
+++ b/lib/src/plural_resolver.dart
@@ -2,25 +2,38 @@ import 'dart:ui';
 
 import 'options.dart';
 
+/// A callback function to determine if exists
+/// the key for an specifc plural modifier
+typedef CheckerKeyFunction = bool Function(
+  String pluralModifier,
+);
+
 class PluralResolver {
   PluralResolver() : super();
 
   /// Returns the plural suffix based on [count] and presented [options].
-  String pluralize(Locale locale, int count, I18NextOptions options) {
-    var result = '';
-    if (count != 1) {
-      final number = _numberForLocale(count.abs(), locale);
-      if (number >= 0) {
-        result = '${options.pluralSuffix}${options.pluralSeparator}$number';
-      } else {
-        result = '${options.pluralSeparator}${options.pluralSuffix}';
-      }
-    }
-    return result;
+  String pluralize(
+    int count,
+    I18NextOptions options,
+    CheckerKeyFunction find,
+  ) {
+    final shouldLookForPluralKeys = count != 1;
+    const resultForNonRequiredPlural = '';
+
+    return !shouldLookForPluralKeys
+        ? resultForNonRequiredPlural
+        : _pluralKey(count, options, find);
   }
 
-  int _numberForLocale(int count, Locale locale) {
-    // TODO: add locale based rules
-    return -1;
+  String _pluralKey(
+    int count,
+    I18NextOptions options,
+    CheckerKeyFunction find,
+  ) {
+    final baseKey = '${options.pluralSeparator}${options.pluralSuffix}';
+    final specicPluralKey = '$baseKey${options.pluralSeparator}$count';
+    final existSpecicPlural = find(specicPluralKey);
+
+    return existSpecicPlural ? specicPluralKey : baseKey;
   }
 }

--- a/lib/src/translator.dart
+++ b/lib/src/translator.dart
@@ -59,7 +59,17 @@ class Translator {
 
     String pluralSuffix;
     if (needsPlural) {
-      pluralSuffix = pluralResolver.pluralize(locale, count, options);
+      pluralSuffix = pluralResolver.pluralize(
+        count,
+        options,
+        (pluralModifier) => _checkForPluralKey(
+          pluralModifier,
+          baseKey: key,
+          locale: locale,
+          namespace: namespace,
+          options: options,
+        ),
+      );
     }
 
     var tempKey = key;
@@ -110,5 +120,22 @@ class Translator {
       result = interpolator.nest(locale, result, translate, variables, options);
     }
     return result;
+  }
+
+  bool _checkForPluralKey(
+    String pluralModifier, {
+    Locale locale,
+    String namespace,
+    String baseKey,
+    I18NextOptions options,
+  }) {
+    final value = resourceStore.retrieve(
+      locale,
+      namespace,
+      '$baseKey$pluralModifier',
+      options,
+    );
+
+    return value != null;
   }
 }

--- a/lib/src/translator.dart
+++ b/lib/src/translator.dart
@@ -62,7 +62,7 @@ class Translator {
       pluralSuffix = pluralResolver.pluralize(
         count,
         options,
-        (pluralModifier) => _checkForPluralKey(
+        (pluralModifier) => _hasPluralKey(
           pluralModifier,
           baseKey: key,
           locale: locale,
@@ -122,7 +122,7 @@ class Translator {
     return result;
   }
 
-  bool _checkForPluralKey(
+  bool _hasPluralKey(
     String pluralModifier, {
     Locale locale,
     String namespace,

--- a/test/i18next_test.dart
+++ b/test/i18next_test.dart
@@ -202,6 +202,9 @@ void main() {
     setUp(() {
       mockKey('friend', 'A friend');
       mockKey('friend_plural', '{{count}} friends');
+      mockKey('clicked', 'You clicked {{count}} time!');
+      mockKey('clicked_2', 'Double click!');
+      mockKey('clicked_plural', 'You clicked {{count}} times!');
     });
 
     test('given key without count', () {
@@ -244,7 +247,24 @@ void main() {
       );
     });
 
-    // TODO: add special pluralization rules
+    test('given key with specific rule count', () {
+      expect(
+        i18next.t('clicked', count: 0),
+        'You clicked 0 times!',
+      );
+      expect(
+        i18next.t('clicked', count: 1),
+        'You clicked 1 time!',
+      );
+      expect(
+        i18next.t('clicked', count: 2),
+        'Double click!',
+      );
+      expect(
+        i18next.t('clicked', count: 99),
+        'You clicked 99 times!',
+      );
+    });
   });
 
   group('contextualization', () {

--- a/test/plural_resolver_test.dart
+++ b/test/plural_resolver_test.dart
@@ -1,0 +1,62 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:i18next/i18next.dart';
+import 'package:i18next/src/plural_resolver.dart';
+import 'package:mockito/mockito.dart';
+
+abstract class FakeCheckerKeyFunction {
+  bool call(String pluralModifier);
+}
+
+class MockCheckerKeyFunction extends Mock implements FakeCheckerKeyFunction {}
+
+void main() {
+  group('PluralResolver', () {
+    MockCheckerKeyFunction checkerKeyFnc;
+    PluralResolver subject;
+
+    setUpAll(() {
+      checkerKeyFnc = MockCheckerKeyFunction();
+      subject = PluralResolver();
+    });
+
+    test('when count is equal 1 returns empty string', () {
+      const count = 1;
+      final result = subject.pluralize(
+        count,
+        I18NextOptions.base,
+        checkerKeyFnc,
+      );
+
+      verifyZeroInteractions(checkerKeyFnc);
+      expect(result, equals(''));
+    });
+
+    group('when count is different than 1', () {
+      test('when exists the specfic key', () {
+        const count = 2;
+        when(checkerKeyFnc.call('_plural_2')).thenReturn(true);
+
+        final result = subject.pluralize(
+          count,
+          I18NextOptions.base,
+          checkerKeyFnc,
+        );
+
+        expect(result, equals('_plural_2'));
+      });
+
+      test('when does not exist the specfic key', () {
+        const count = 2;
+        when(checkerKeyFnc.call('_plural_2')).thenReturn(false);
+
+        final result = subject.pluralize(
+          count,
+          I18NextOptions.base,
+          checkerKeyFnc,
+        );
+
+        expect(result, equals('_plural'));
+      });
+    });
+  });
+}

--- a/test/plural_resolver_test.dart
+++ b/test/plural_resolver_test.dart
@@ -3,60 +3,82 @@ import 'package:i18next/i18next.dart';
 import 'package:i18next/src/plural_resolver.dart';
 import 'package:mockito/mockito.dart';
 
-abstract class FakeCheckerKeyFunction {
+class MockKeyExists extends Mock {
   bool call(String pluralModifier);
 }
 
-class MockCheckerKeyFunction extends Mock implements FakeCheckerKeyFunction {}
-
 void main() {
-  group('PluralResolver', () {
-    MockCheckerKeyFunction checkerKeyFnc;
-    PluralResolver subject;
+  MockKeyExists keyExists;
+  PluralResolver subject;
 
-    setUpAll(() {
-      checkerKeyFnc = MockCheckerKeyFunction();
-      subject = PluralResolver();
-    });
+  setUp(() {
+    keyExists = MockKeyExists();
+    subject = PluralResolver();
+  });
 
-    test('when count is equal 1 returns empty string', () {
-      const count = 1;
+  group('given count equals 0', () {
+    test('when exists the specfic key', () {
+      when(keyExists.call('_0')).thenReturn(true);
+      const count = 0;
       final result = subject.pluralize(
         count,
         I18NextOptions.base,
-        checkerKeyFnc,
+        keyExists,
       );
 
-      verifyZeroInteractions(checkerKeyFnc);
-      expect(result, equals(''));
+      expect(result, equals('_0'));
     });
 
-    group('when count is different than 1', () {
-      test('when exists the specfic key', () {
-        const count = 2;
-        when(checkerKeyFnc.call('_plural_2')).thenReturn(true);
+    test('when does not exist the specfic key', () {
+      when(keyExists.call('_0')).thenReturn(false);
+      const count = 0;
+      final result = subject.pluralize(
+        count,
+        I18NextOptions.base,
+        keyExists,
+      );
 
-        final result = subject.pluralize(
-          count,
-          I18NextOptions.base,
-          checkerKeyFnc,
-        );
+      expect(result, equals('_plural'));
+    });
+  });
 
-        expect(result, equals('_plural_2'));
-      });
+  test('given count equals 1', () {
+    const count = 1;
+    final result = subject.pluralize(
+      count,
+      I18NextOptions.base,
+      keyExists,
+    );
 
-      test('when does not exist the specfic key', () {
-        const count = 2;
-        when(checkerKeyFnc.call('_plural_2')).thenReturn(false);
+    verifyZeroInteractions(keyExists);
+    expect(result, equals(''));
+  });
 
-        final result = subject.pluralize(
-          count,
-          I18NextOptions.base,
-          checkerKeyFnc,
-        );
+  group('when count is different than 1', () {
+    test('when exists the specfic key', () {
+      const count = 2;
+      when(keyExists.call('_2')).thenReturn(true);
 
-        expect(result, equals('_plural'));
-      });
+      final result = subject.pluralize(
+        count,
+        I18NextOptions.base,
+        keyExists,
+      );
+
+      expect(result, equals('_2'));
+    });
+
+    test('when does not exist the specfic key', () {
+      const count = 2;
+      when(keyExists.call('_2')).thenReturn(false);
+
+      final result = subject.pluralize(
+        count,
+        I18NextOptions.base,
+        keyExists,
+      );
+
+      expect(result, equals('_plural'));
     });
   });
 }


### PR DESCRIPTION
fix #6 

## The definition of localizations

```json
{
  "clicked": "You clicked {{count}} time!",
  "clicked_0": "No clicks",
  "clicked_2": "Double tap",
  "clicked_plural": "You clicked {{count}} times!"
}
```