### PR TITLE
Use Diagnosticable instead of DiagnosticableMixin in I18NextOptions

### DIFF
--- a/lib/src/options.dart
+++ b/lib/src/options.dart
@@ -5,7 +5,7 @@ import 'package:flutter/foundation.dart';
 import 'utils.dart';
 
 /// Contains all options for [I18Next] to work properly.
-class I18NextOptions with DiagnosticableMixin {
+class I18NextOptions with Diagnosticable {
   I18NextOptions({
     this.fallbackNamespace,
     this.namespaceSeparator,


### PR DESCRIPTION
Removed DiagnosticableMixin in favor of Diagnosticable #16