### PR TITLE
Bumps 0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Next version
 
+## [0.4.1]
+
+* Officializes the null-safety migration
+
 ## [0.4.0-nullsafety.0]
 
 * Migrates the codebase to flutter stable 2.0.3 + null-safety

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: i18next
 description: A localization formatter based on the i18next standard. It is not yet a fully i18n tool only the formatting itself.
-version: 0.4.0-nullsafety.0
+version: 0.4.1
 repository: https://github.com/nubank/i18next
 homepage: https://github.com/nubank/i18next
 


### PR DESCRIPTION
Officializes the null-safety migration in 0.4.1

