### PR TITLE
implement shouldReload

### DIFF
--- a/lib/src/data_sources/asset_bundle_data_source.dart
+++ b/lib/src/data_sources/asset_bundle_data_source.dart
@@ -95,5 +95,8 @@ class AssetBundleLocalizationDataSource implements LocalizationDataSource {
           bundle == other.bundle;
 
   @override
-  int get hashCode => bundlePath.hashCode ^ bundle.hashCode;
+  int get hashCode => hashValues(
+        bundlePath,
+        bundle,
+      );
 }

--- a/lib/src/data_sources/asset_bundle_data_source.dart
+++ b/lib/src/data_sources/asset_bundle_data_source.dart
@@ -85,4 +85,15 @@ class AssetBundleLocalizationDataSource implements LocalizationDataSource {
     }
     return namespaces;
   }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is AssetBundleLocalizationDataSource &&
+          runtimeType == other.runtimeType &&
+          bundlePath == other.bundlePath &&
+          bundle == other.bundle;
+
+  @override
+  int get hashCode => bundlePath.hashCode ^ bundle.hashCode;
 }

--- a/lib/src/i18next_localization_delegate.dart
+++ b/lib/src/i18next_localization_delegate.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/widgets.dart';
+import 'package:flutter/foundation.dart';
 
 import 'data_sources/localization_data_source.dart';
 import 'i18next.dart';
@@ -49,7 +50,15 @@ class I18NextLocalizationDelegate extends LocalizationsDelegate<I18Next> {
       locales.any((l) => l.languageCode == locale.languageCode);
 
   @override
-  bool shouldReload(I18NextLocalizationDelegate old) => true;
+  bool shouldReload(I18NextLocalizationDelegate old) {
+    if (!listEquals(locales, old.locales) ||
+        resourceStore != old.resourceStore ||
+        dataSource != old.dataSource ||
+        options != old.options) {
+      return true;
+    }
+    return false;
+  }
 
   /// Normalizes [locale] in case it is not fully supported, but a shorter
   /// or specific one might be.

--- a/lib/src/i18next_localization_delegate.dart
+++ b/lib/src/i18next_localization_delegate.dart
@@ -51,13 +51,10 @@ class I18NextLocalizationDelegate extends LocalizationsDelegate<I18Next> {
 
   @override
   bool shouldReload(I18NextLocalizationDelegate old) {
-    if (!listEquals(locales, old.locales) ||
+    return !listEquals(locales, old.locales) ||
         resourceStore != old.resourceStore ||
         dataSource != old.dataSource ||
-        options != old.options) {
-      return true;
-    }
-    return false;
+        options != old.options;
   }
 
   /// Normalizes [locale] in case it is not fully supported, but a shorter

--- a/lib/src/resource_store.dart
+++ b/lib/src/resource_store.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 
 import '../utils.dart';
@@ -70,4 +71,14 @@ class ResourceStore {
     final value = evaluate(path, _data);
     return value is String ? value : null;
   }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ResourceStore &&
+      runtimeType == other.runtimeType &&
+      mapEquals(_data, other._data);
+
+  @override
+  int get hashCode => _data.hashCode;
 }

--- a/lib/src/resource_store.dart
+++ b/lib/src/resource_store.dart
@@ -76,8 +76,8 @@ class ResourceStore {
   bool operator ==(Object other) =>
       identical(this, other) ||
       other is ResourceStore &&
-      runtimeType == other.runtimeType &&
-      mapEquals(_data, other._data);
+          runtimeType == other.runtimeType &&
+          mapEquals(_data, other._data);
 
   @override
   int get hashCode => _data.hashCode;


### PR DESCRIPTION
I noticed that this method always returns true, which leads to unnessecary reloads of the localizationDataSource.

Users will have to implement == on other LocalizationDataSources.