### PR TITLE
[feature]: add getNamespace to ResourceStore

### DIFF
--- a/lib/src/resource_store.dart
+++ b/lib/src/resource_store.dart
@@ -15,6 +15,10 @@ class ResourceStore {
 
   final Map<Locale, Map<String, dynamic>> _data;
 
+  /// get all data from [locale] and [namespace]
+  Map<String, dynamic>? getNamespace(Locale locale, String namespace) =>
+      _data[locale]?[namespace];
+
   /// Registers the [namespace] to the store for the given [locale].
   ///
   /// [locale], [namespace], and [data] cannot be null.


### PR DESCRIPTION
Closes https://github.com/williamhjcho/i18next/issues/17

This feature makes it possible to retrieve all key-value pairs for the specific locale and namespace.

This is useful for example if you need a set of questions and it's corresponding answers in a specific language and provide them for the user to fill out a form. For those use cases it is necessary to iterate through a specific set and do you stuff on it. Here is a case where we don't know the key and have to iterate through the keys (so retrieve doesn't fit our needs here!).

For further informations see mentioned issue.

@williamhjcho 